### PR TITLE
Redirecting /user to dashboard

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: "/user",
+        destination: "/user/dashboard",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Before: /user would direct to an error page.
After: /user now directs to the dashboard.
- Closes issue #298 