### PR TITLE
Reroute logged-in user to dashboard

### DIFF
--- a/components/ProtectedPage.jsx
+++ b/components/ProtectedPage.jsx
@@ -7,9 +7,19 @@ const ProtectedPage = ({ title, children, restrictions }) => {
   const { data: session, status } = useSession();
 
   useEffect(() => {
+    console.log(status === "authenticated");
+    console.log(session.user.role === "member");
+    console.log(router.pathname === "/");
     if (status === "unauthenticated") {
       console.log("Not signed in");
       router.push("/");
+    }
+    if (
+      status === "authenticated" &&
+      session.user.role !== "admin" &&
+      router.pathname === "/"
+    ) {
+      router.push("/user/dashboard");
     }
     if (
       status === "authenticated" &&
@@ -19,7 +29,7 @@ const ProtectedPage = ({ title, children, restrictions }) => {
       console.log("Dont have admin permissions");
       router.push("/");
     }
-  }, [status]);
+  }, [status, router]);
 
   return (
     <>

--- a/components/ProtectedPage.jsx
+++ b/components/ProtectedPage.jsx
@@ -7,19 +7,9 @@ const ProtectedPage = ({ title, children, restrictions }) => {
   const { data: session, status } = useSession();
 
   useEffect(() => {
-    console.log(status === "authenticated");
-    console.log(session.user.role === "member");
-    console.log(router.pathname === "/");
     if (status === "unauthenticated") {
       console.log("Not signed in");
       router.push("/");
-    }
-    if (
-      status === "authenticated" &&
-      session.user.role !== "admin" &&
-      router.pathname === "/"
-    ) {
-      router.push("/user/dashboard");
     }
     if (
       status === "authenticated" &&

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,11 @@ const nextConfig = {
         destination: "/user/dashboard",
         permanent: true,
       },
+      {
+        source: "/",
+        destination: "/user/dashboard",
+        permanent: true,
+      },
     ];
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -8,11 +8,6 @@ const nextConfig = {
         destination: "/user/dashboard",
         permanent: true,
       },
-      {
-        source: "/",
-        destination: "/user/dashboard",
-        permanent: true,
-      },
     ];
   },
 };

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,17 +2,30 @@ import PrimaryLogo from "@/components/PrimaryLogo";
 import Welcome from "@/components/Welcome";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/router";
 
 const Index = () => {
+  const { status } = useSession();
+  const router = useRouter();
+
+  if (status === "authenticated") {
+    router.push("/user/dashboard");
+  }
+
   return (
-    <Row className="flex justify-center items-center bg-code-black h-screen w-full">
-      <Col xl={6}>
-        <PrimaryLogo />
-      </Col>
-      <Col xl={6}>
-        <Welcome />
-      </Col>
-    </Row>
+    <>
+      {status === "unauthenticated" && (
+        <Row className="flex justify-center items-center bg-code-black h-screen w-full">
+          <Col xl={6}>
+            <PrimaryLogo />
+          </Col>
+          <Col xl={6}>
+            <Welcome />
+          </Col>
+        </Row>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
The index page should reroute logged-in users to the dashboard, but I don't think this is ideal. If the user is not logged in, the website routes the user to the dashboard and back to the welcome page. I'm unsure how to check whether the user is logged in using next.config.js.

I tried a different approach using useRoute and useSession in index.js to check if the user is logged in (similar to ProtectedPage.jsx), but for some reason, the status returned undefined.

- Closes issue #303 