### PR TITLE
Styled loading screen

### DIFF
--- a/components/LoadingScreen.jsx
+++ b/components/LoadingScreen.jsx
@@ -1,0 +1,16 @@
+import { CgSpinner } from "react-icons/cg";
+
+const LoadingScreen = () => {
+  return (
+    <div className="bg-code-black w-full ">
+      <div className="flex flex-col justify-center items-center text-code-white h-[calc(100vh-64px)]">
+        <div>
+          <CgSpinner className="animate-spin text-3xl " />
+        </div>
+        <div className="font-bold text-2xl pt-3">Loading...</div>
+      </div>
+    </div>
+  );
+};
+
+export default LoadingScreen;

--- a/components/ProtectedPage.jsx
+++ b/components/ProtectedPage.jsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
 import React, { useEffect } from "react";
 import { useSession } from "next-auth/react";
+import LoadingScreen from "../components/LoadingScreen";
 
 const ProtectedPage = ({ title, children, restrictions }) => {
   const router = useRouter();
@@ -23,7 +24,7 @@ const ProtectedPage = ({ title, children, restrictions }) => {
 
   return (
     <>
-      {status === "loading" && <>LOADING</>}
+      {status === "loading" && <LoadingScreen />}
       {status === "authenticated" && (
         <div>
           <title>{title}</title>


### PR DESCRIPTION
Before: 
![loadingbefore](https://github.com/acm-ucr/bitByBIT/assets/91030482/d959edae-fe69-4ca6-8008-82f7bcd2bfbb)

After:
![loadingscreen](https://github.com/acm-ucr/bitByBIT/assets/91030482/329745b5-5726-4128-a52c-0eb38b9a5024)

-Closes issue #323 