### PR TITLE
Redirect invalid problem id to 404 page

### DIFF
--- a/pages/user/problems/[id].js
+++ b/pages/user/problems/[id].js
@@ -72,6 +72,9 @@ const Problems = () => {
           .then((response) => setProblem(response.data));
       } catch (error) {
         console.error("Error fetching problem:", error);
+        if (error.response.status === 400) {
+          router.push("/404");
+        }
       }
     };
 


### PR DESCRIPTION
Simply redirected the user to a 404 page if fetchProblems returns a 400 status. This should work even if you reload a valid problem page.

![invalidID](https://github.com/acm-ucr/bitByBIT/assets/91030482/ae838874-d1bd-45f5-b696-4013d5008f0f)
![validID](https://github.com/acm-ucr/bitByBIT/assets/91030482/1ca45c4e-ada6-4f59-ac74-7990887e907e)