### PR TITLE
Make Console Resizable

### DIFF
--- a/components/Console.jsx
+++ b/components/Console.jsx
@@ -75,15 +75,19 @@ const Console = ({ problem }) => {
   };
 
   return (
-    <div className="p-2.5 text-code-white flex-col font-readex bg-code-darkerpurple">
+    <div className="flex flex-col p-2.5 h-full text-code-white font-readex bg-code-darkerpurple">
       <ConsoleStateToggle state={state} onUpdateState={setState} />
-      {state === 0 && <TestCases problem={problem} />}
+      {state === 0 && (
+        <div className="h-full">
+          <TestCases problem={problem} />
+        </div>
+      )}
       {state === 1 && (
-        <div className="h-40">
+        <div className="h-full">
           <Results />
         </div>
       )}
-      <div className="flex flex-row gap-4 justify-end">
+      <div className="flex flex-row justify-end">
         <div className="flex text-code-black gap-2">
           <button
             disabled={isRunning}

--- a/components/TestCases.jsx
+++ b/components/TestCases.jsx
@@ -36,7 +36,7 @@ const TestCases = ({ problem }) => {
   const [state, setState] = useState(0);
 
   return (
-    <div className="h-40">
+    <div className="h-full">
       <TestCasesToggle state={state} onUpdateState={setState} />
       <TestCaseInput tests={problem.testcases} state={state} />
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "react": "18.2.0",
         "react-bootstrap": "^2.7.0",
         "react-dom": "18.2.0",
-        "react-icons": "^4.7.1"
+        "react-icons": "^4.7.1",
+        "react-resizable-panels": "^0.0.55"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.13",
@@ -6576,6 +6577,15 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "node_modules/react-resizable-panels": {
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-0.0.55.tgz",
+      "integrity": "sha512-J/LTFzUEjJiqwSjVh8gjUXkQDA8MRPjARASfn++d2+KOgA+9UcRYUfE3QBJixer2vkk+ffQ4cq3QzWzzHgqYpQ==",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -12492,6 +12502,12 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-resizable-panels": {
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-0.0.55.tgz",
+      "integrity": "sha512-J/LTFzUEjJiqwSjVh8gjUXkQDA8MRPjARASfn++d2+KOgA+9UcRYUfE3QBJixer2vkk+ffQ4cq3QzWzzHgqYpQ==",
+      "requires": {}
     },
     "react-transition-group": {
       "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react": "18.2.0",
     "react-bootstrap": "^2.7.0",
     "react-dom": "18.2.0",
-    "react-icons": "^4.7.1"
+    "react-icons": "^4.7.1",
+    "react-resizable-panels": "^0.0.55"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.13",

--- a/pages/user/problems/[id].js
+++ b/pages/user/problems/[id].js
@@ -1,63 +1,15 @@
 import ProblemDescription from "@/components/ProblemDescription";
-import ProblemSolution from "@/components/ProblemSolution";
 import ProblemStateToggle from "@/components/ProblemStateToggle";
 import CodeEditor from "@/components/CodeEditor";
 import Console from "@/components/Console";
-import React, { useState, useRef, useEffect } from "react";
+import { useState, useEffect } from "react";
 import LanguageSelector from "@/components/LanguageSelector";
 import { FaCircle } from "react-icons/fa";
 import ProtectedPage from "@/components/ProtectedPage";
 import { useRouter } from "next/router";
 import axios from "axios";
 import LoadingScreen from "@/components/LoadingScreen";
-
-const useResize = (containerRef, panelRef, initialWidth, minWidth = 0) => {
-  const [panelWidth, setPanelWidth] = useState(initialWidth);
-
-  const onResizeStart = () => {
-    if (panelRef.current) {
-      panelRef.current.style.pointerEvents = "none";
-      panelRef.current.style.userSelect = "none";
-    }
-    if (containerRef.current) {
-      containerRef.current.classList.add("resizing");
-      containerRef.current.style.cursor = "ew-resize";
-    }
-    if (typeof window !== "undefined") {
-      window.addEventListener("pointermove", onResize);
-      window.addEventListener("pointerup", onResizeEnd);
-    }
-  };
-
-  const onResize = (e) => {
-    if (containerRef.current) {
-      const bounds = containerRef.current.getBoundingClientRect();
-      const newWidth = e.clientX - bounds.left;
-      if (newWidth >= minWidth) {
-        setPanelWidth(newWidth);
-      } else {
-        setPanelWidth(minWidth);
-      }
-    }
-  };
-
-  const onResizeEnd = () => {
-    if (panelRef.current) {
-      panelRef.current.style.pointerEvents = "auto";
-      panelRef.current.style.userSelect = "auto";
-    }
-    if (containerRef.current) {
-      containerRef.current.classList.remove("resizing");
-      containerRef.current.style.cursor = "auto";
-    }
-    if (typeof window !== "undefined") {
-      window.removeEventListener("pointermove", onResize);
-      window.removeEventListener("pointerup", onResizeEnd);
-    }
-  };
-
-  return { panelWidth, onResizeStart };
-};
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 const Problems = () => {
   const [loaded, setLoaded] = useState(0);
@@ -86,78 +38,43 @@ const Problems = () => {
     }
   }, [id]);
 
-  const containerRef = useRef();
-  const panelRef = useRef();
-  const handleWidth = 16;
-  let maxContainerWidth;
-  if (typeof window !== "undefined") {
-    maxContainerWidth = window.innerWidth;
-  }
-
-  const { panelWidth, onResizeStart } = useResize(
-    containerRef,
-    panelRef,
-    maxContainerWidth / 2,
-    maxContainerWidth / 3
-  );
-
   return (
     <>
       {!loaded && <LoadingScreen />}
       {loaded && (
         <ProtectedPage title="Problem" restrictions={[]}>
-          <div
-            ref={containerRef}
-            style={{
-              maxWidth: `${maxContainerWidth}px`,
-            }}
-            className="flex w-full h-[calc(100vh-64px)]"
-          >
-            <div
-              ref={panelRef}
-              style={{
-                width: `${panelWidth}px`,
-                paddingRight: `${handleWidth}px`,
-              }}
-              className="relative flex flex-col h-full max-w-full"
-            >
-              <ProblemStateToggle state={state} onUpdateState={setState} />
-              {state === 0 && <ProblemDescription problem={problem} />}
-              {state === 1 && (
-                <ProblemSolution
-                  problem={problem}
-                  entries={[
-                    {
-                      methodName: "TEST METHOD",
-                      description: "TEST DESCRIPTION",
-                      implementation: "TEST IMPLEMENTATION",
-                      timeComplexity: "TEST TIME COMPLEXITY",
-                      spaceComplexity: "TEST SPACE COMPLEXITY",
-                    },
-                  ]}
-                />
-              )}
-
-              <div
-                style={{
-                  width: `${handleWidth}px`,
-                }}
-                onPointerDown={onResizeStart}
-                className="bg-code-black absolute top-0 right-0 h-full text-code-white cursor-ew-resize text-center place-content-center flex justify-center items-center flex-col px-2"
-              >
+          <div className="flex w-full h-[calc(100vh-64px)]">
+            <PanelGroup direction="horizontal">
+              <Panel defaultSize={50} minSize={20}>
+                <ProblemStateToggle state={state} onUpdateState={setState} />
+                <ProblemDescription problem={problem} />
+              </Panel>
+              <PanelResizeHandle className="flex flex-col bg-code-black h-full text-code-white place-content-center px-1">
                 <FaCircle className="text-[8px] my-1" />
                 <FaCircle className="text-[8px] my-1" />
                 <FaCircle className="text-[8px] my-1" />
-              </div>
-            </div>
-            <div className="flex flex-col flex-grow">
-              <LanguageSelector />
-              <div className="flex flex-col flex-grow h-full overflow-auto">
-                <CodeEditor problem={problem} />
-              </div>
-              <div className="w-full text-code-purple h-6 "></div>
-              <Console problem={problem} />
-            </div>
+              </PanelResizeHandle>
+              <Panel defaultSize={50} minSize={20}>
+                <PanelGroup direction="vertical">
+                  <Panel defaultSize={50} minSize={20}>
+                    <div className="flex flex-col h-full overflow-auto">
+                      <LanguageSelector />
+                      <CodeEditor problem={problem} />
+                    </div>
+                  </Panel>
+                  <PanelResizeHandle className="flex bg-code-black text-code-white place-content-center px-1">
+                    <FaCircle className="text-[8px] m-1" />
+                    <FaCircle className="text-[8px] m-1" />
+                    <FaCircle className="text-[8px] m-1" />
+                  </PanelResizeHandle>
+                  <Panel defaultSize={25} minSize={25}>
+                    <div className="h-full">
+                      <Console problem={problem} />
+                    </div>
+                  </Panel>
+                </PanelGroup>
+              </Panel>
+            </PanelGroup>
           </div>
         </ProtectedPage>
       )}


### PR DESCRIPTION
![image](https://github.com/acm-ucr/bitByBIT/assets/54488379/9c617b4d-4fa0-4083-b016-2d88575de29f)
![image](https://github.com/acm-ucr/bitByBIT/assets/54488379/61035097-cd3d-4ede-b04b-0922a52168d7)
![image](https://github.com/acm-ucr/bitByBIT/assets/54488379/faeddb8d-1eab-4c54-8f63-72017dcd5f78)

* Fixed resizable panels by using "react-resizable-panels" library
* Works a lot better now
* Both console and code editor can be resized now
* Closes #350 